### PR TITLE
Better power calculation

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -19,3 +19,8 @@ jobs:
           pip install -U platformio
       - name: Build
         run: platformio run
+      - name: Archive bin
+        uses: actions/upload-artifact@v2
+        with:
+          name: bin-artifact
+          path: .pio/build/**/firmware.bin

--- a/eppg-controller.ino
+++ b/eppg-controller.ino
@@ -21,7 +21,7 @@
 #include <Wire.h>
 #include <extEEPROM.h>  // https://github.com/PaoloP74/extEEPROM
 
-#include "inc/sp140-globals.h" // device config
+#include "inc/sp140-globals.h"  // device config
 
 using namespace ace_button;
 
@@ -72,7 +72,6 @@ void setup() {
   //Serial.print(F("Booting up (USB) V"));
   //Serial.print(VERSION_MAJOR + "." + VERSION_MINOR);
 
-  //pinMode(LED_SW, OUTPUT);   // set up the external LED pin
   pinMode(LED_SW, OUTPUT);   // set up the internal LED2 pin
 
   analogReadResolution(12);     // M0 chip provides 12bit resolution
@@ -328,7 +327,7 @@ void updateDisplay() {
   display.setTextColor(BLACK);
   float avgVoltage = getBatteryVoltSmoothed();
   batteryPercent = getBatteryPercent(avgVoltage);  // multi-point line
-
+  // change battery color based on charge
   if (batteryPercent >= 30) {
     display.fillRect(0, 0, mapf(batteryPercent, 0, 100, 0, 108), 36, GREEN);
   } else if (batteryPercent >= 15) {
@@ -356,7 +355,7 @@ void updateDisplay() {
     batteryFlag = true;
     display.fillRect(map(batteryPercent, 0,100, 0,108), 0, map(batteryPercent, 0,100, 108,0), 36, DEFAULT_BG_COLOR);
   }
-
+  // cross out battery box if battery is dead
   if (batteryPercent <= 5) {
     display.drawLine(0, 1, 106, 36, RED);
     display.drawLine(0, 0, 108, 36, RED);
@@ -557,7 +556,7 @@ unsigned long prevPwrMillis = 0;
 
 void trackPower() {
   unsigned long currentPwrMillis = millis();
-  unsigned long msec_diff = (currentPwrMillis - prevPwrMillis); // 0.30 sec
+  unsigned long msec_diff = (currentPwrMillis - prevPwrMillis);  // eg 0.30 sec
   prevPwrMillis = currentPwrMillis;
 
   if (armed) {

--- a/eppg-controller.ino
+++ b/eppg-controller.ino
@@ -86,7 +86,7 @@ void setup() {
   ledBlinkThread.setInterval(500);
 
   displayThread.onRun(updateDisplay);
-  displayThread.setInterval(100);
+  displayThread.setInterval(200);
 
   buttonThread.onRun(checkButtons);
   buttonThread.setInterval(5);
@@ -98,7 +98,7 @@ void setup() {
   telemetryThread.setInterval(50);
 
   counterThread.onRun(trackPower);
-  counterThread.setInterval(500);
+  counterThread.setInterval(250);
 
   int countdownMS = Watchdog.enable(5000);
   uint8_t eepStatus = eep.begin(eep.twiClock100kHz);
@@ -553,9 +553,20 @@ void removeCruise(bool alert) {
   }
 }
 
+unsigned long prevPwrMillis = 0;    
+
 void trackPower() {
-  // runs 2x/sec so convert to hours
+  unsigned long currentPwrMillis = millis();
+  float sec_diff = (currentPwrMillis - prevPwrMillis)/1000.0;
+  float sec_fraction = 60 * sec_diff;
+  prevPwrMillis = currentPwrMillis;
+
+  Serial.print(millis());
+  Serial.print(",");
+  Serial.print(sec_fraction);
+  Serial.print(",");
+  Serial.println(sec_diff);
   if (armed) {
-    wattsHoursUsed += watts/60/60/2;
+    wattsHoursUsed += round(watts/60/60/sec_fraction);
   }
 }

--- a/eppg-controller.ino
+++ b/eppg-controller.ino
@@ -553,20 +553,14 @@ void removeCruise(bool alert) {
   }
 }
 
-unsigned long prevPwrMillis = 0;    
+unsigned long prevPwrMillis = 0;
 
 void trackPower() {
   unsigned long currentPwrMillis = millis();
-  float sec_diff = (currentPwrMillis - prevPwrMillis)/1000.0;
-  float sec_fraction = 60 * sec_diff;
+  unsigned long msec_diff = (currentPwrMillis - prevPwrMillis); // 0.30 sec
   prevPwrMillis = currentPwrMillis;
 
-  Serial.print(millis());
-  Serial.print(",");
-  Serial.print(sec_fraction);
-  Serial.print(",");
-  Serial.println(sec_diff);
   if (armed) {
-    wattsHoursUsed += round(watts/60/60/sec_fraction);
+    wattsHoursUsed += round(watts/60/60*msec_diff)/1000.0;
   }
 }

--- a/eppg-controller.ino
+++ b/eppg-controller.ino
@@ -100,7 +100,7 @@ void setup() {
   counterThread.onRun(trackPower);
   counterThread.setInterval(250);
 
-  int countdownMS = Watchdog.enable(5000);
+  Watchdog.enable(5000);
   uint8_t eepStatus = eep.begin(eep.twiClock100kHz);
   refreshDeviceData();
   setup140();

--- a/inc/config.h
+++ b/inc/config.h
@@ -17,8 +17,6 @@
 
 // Batt setting now configurable by user. Read from device data
 #define BATT_MIN_V 60.0  // 24 * 2.5V per cell
-#define BATT_MID_V 88.8  // 24 *  3.7V per cell
-#define BATT_MAX_V 100.4  // 24 * 4.2V per cell
 
 #define REARM_COOLDOWN 2.0
 
@@ -27,7 +25,7 @@
 #define VOLT_OFFSET 1.5
 
 #define VERSION_MAJOR 5
-#define VERSION_MINOR 2
+#define VERSION_MINOR 3
 
 #define CRUISE_GRACE 1.5  // 1.5 sec period to get off throttle
 #define CRUISE_MAX 300  // 5 min max cruising

--- a/inc/config.h
+++ b/inc/config.h
@@ -17,7 +17,7 @@
 
 // Batt setting now configurable by user. Read from device data
 #define BATT_MIN_V 60.0  // 24 * 2.5V per cell
-#define BATT_MID_V 86.4  // 24 *  3.6V per cell
+#define BATT_MID_V 88.8  // 24 *  3.7V per cell
 #define BATT_MAX_V 100.4  // 24 * 4.2V per cell
 
 #define REARM_COOLDOWN 2.0

--- a/platformio.ini
+++ b/platformio.ini
@@ -25,14 +25,14 @@ lib_deps =
 	AceButton@1.8.3
 	Adafruit DRV2605 Library@1.2.0
 	Adafruit SleepyDog Library@1.5.0
-	Adafruit TinyUSB Library@1.5.0
+	Adafruit TinyUSB Library@1.6.0
 	ArduinoJson@6.17.3
 	ArduinoThread@2.1.1
 	ResponsiveAnalogRead@1.2.1
 	Time@1.6.1
 	extEEPROM@3.4.1
 	adafruit/Adafruit BusIO@1.9.3
-	adafruit/Adafruit BMP3XX Library@1.1.0
+	adafruit/Adafruit BMP3XX Library@2.0.2
 	adafruit/Adafruit ST7735 and ST7789 Library@1.7.5
 	https://github.com/rlogiacco/CircularBuffer
 lib_ignore =

--- a/platformio.ini
+++ b/platformio.ini
@@ -22,18 +22,18 @@ framework = arduino
 build_flags = -D USE_TINYUSB
 lib_deps =
 	Adafruit GFX Library@1.10.12
-	AceButton@1.8.3
-	Adafruit DRV2605 Library@1.2.0
-	Adafruit SleepyDog Library@1.5.0
-	Adafruit TinyUSB Library@1.6.0
+	AceButton@1.9.1
+	Adafruit DRV2605 Library@1.1.2
+	Adafruit SleepyDog Library@1.6.0
+	Adafruit TinyUSB Library@1.7.1
 	ArduinoJson@6.17.3
 	ArduinoThread@2.1.1
 	ResponsiveAnalogRead@1.2.1
-	Time@1.6.1
+	Time@1.6.0
 	extEEPROM@3.4.1
-	adafruit/Adafruit BusIO@1.9.3
-	adafruit/Adafruit BMP3XX Library@2.0.2
-	adafruit/Adafruit ST7735 and ST7789 Library@1.7.5
+	adafruit/Adafruit BusIO@1.7.5
+	adafruit/Adafruit BMP3XX Library@2.1.1
+	adafruit/Adafruit ST7735 and ST7789 Library@1.6.1
 	https://github.com/rlogiacco/CircularBuffer
 lib_ignore =
 	Adafruit Circuit Playground

--- a/platformio.ini
+++ b/platformio.ini
@@ -21,19 +21,20 @@ board = adafruit_feather_m0
 framework = arduino
 build_flags = -D USE_TINYUSB
 lib_deps =
-	Adafruit GFX Library@^1.10.12
+	Adafruit GFX Library@1.10.12
 	AceButton@1.8.3
 	Adafruit DRV2605 Library@1.2.0
 	Adafruit SSD1306@2.3.0
 	Adafruit SleepyDog Library@1.5.0
 	Adafruit TinyUSB Library@1.5.0
-	ArduinoJson@6.17.2
+	ArduinoJson@6.17.3
 	ArduinoThread@2.1.1
 	ResponsiveAnalogRead@1.2.1
 	Time@1.6.1
 	extEEPROM@3.4.1
 	adafruit/Adafruit BusIO@1.9.3
 	adafruit/Adafruit BMP3XX Library@1.1.0
+	adafruit/Adafruit ST7735 and ST7789 Library@1.7.5
 	https://github.com/rlogiacco/CircularBuffer
 lib_ignore =
 	Adafruit Circuit Playground

--- a/power.ino
+++ b/power.ino
@@ -6,24 +6,26 @@
 float getBatteryPercent(float voltage) {
   float battPercent = 0;
 
-  if (voltage > 92.88) {
-    battPercent = mapf(voltage, 92.88, 94.8, 80, 90);
-  } else if (voltage > 90.24) {
-    battPercent = mapf(voltage, 90.24, 92.88, 70, 80);
-  } else if (voltage > 85.44) {
-    battPercent = mapf(voltage, 85.44, 90.24, 60, 70);
-  } else if (voltage > 84.72) {
-    battPercent = mapf(voltage, 84.72, 85.44, 50, 60);
+  if (voltage > 94.8) {
+    battPercent = mapf(voltage, 94.8, 99.6, 90, 100);
+  } else if (voltage > 93.36) {
+    battPercent = mapf(voltage, 93.36, 94.8, 80, 90);
+  } else if (voltage > 91.68) {
+    battPercent = mapf(voltage, 91.68, 93.36, 70, 80);
+  } else if (voltage > 89.76) {
+    battPercent = mapf(voltage, 89.76, 91.68, 60, 70);
+  } else if (voltage > 87.6) {
+    battPercent = mapf(voltage, 87.6, 89.76, 50, 60);
+  } else if (voltage > 85.2) {
+    battPercent = mapf(voltage, 85.2, 87.6, 40, 50);
   } else if (voltage > 82.32) {
-    battPercent = mapf(voltage, 82.32, 84.72, 40, 50);
-  } else if (voltage > 78.72) {
-    battPercent = mapf(voltage, 78.72, 82.32, 30, 40);
-  } else if (voltage > 69.84) {
-    battPercent = mapf(voltage, 69.84, 78.72, 20, 30);
-  } else if (voltage > 68.4) {
-    battPercent = mapf(voltage, 68.4, 69.84, 10, 20);
-  } else if (voltage > 60) {
-    battPercent = mapf(voltage, 60, 68.4, 0, 10);
+    battPercent = mapf(voltage, 82.32, 85.2, 30, 40);
+  } else if (voltage > 80.16) {
+    battPercent = mapf(voltage, 80.16, 82.32, 20, 30);
+  } else if (voltage > 78) {
+    battPercent = mapf(voltage, 78, 80.16, 10, 20);
+  } else if (voltage > 60.96) {
+    battPercent = mapf(voltage, 60.96, 78, 0, 10);
   }
   return constrain(battPercent, 0, 100);
 }

--- a/power.ino
+++ b/power.ino
@@ -2,9 +2,10 @@
 // OpenPPG
 
 // simple set of data points from load testing
+// maps voltage to battery percentage
 float getBatteryPercent(float voltage) {
   float battPercent = 0;
-  
+
   if (voltage > 92.88) {
     battPercent = mapf(voltage, 92.88, 94.8, 80, 90);
   } else if (voltage > 90.24) {

--- a/power.ino
+++ b/power.ino
@@ -1,0 +1,37 @@
+// Copyright 2021 <Zach Whitehead>
+// OpenPPG
+
+// simple set of data points from load testing
+float getBatteryPercent(float voltage) {
+  float battPercent = 0;
+  if (voltage > 92.4) {
+    battPercent = mapf(voltage, 92.4, 100.8, 90, 100);
+  } else if (voltage > 90.48) {
+    battPercent = mapf(voltage, 90.48, 92.4, 80, 90);
+  } else if (voltage > 87.84) {
+    battPercent = mapf(voltage, 87.84, 90.48, 70, 80);
+  } else if (voltage > 85.44) {
+    battPercent = mapf(voltage, 85.44, 87.84, 60, 70);
+  } else if (voltage > 82.32) {
+    battPercent = mapf(voltage, 82.32, 85.44, 50, 60);
+  } else if (voltage > 79.92) {
+    battPercent = mapf(voltage, 79.92, 82.32, 40, 50);
+  } else if (voltage > 76.32) {
+    battPercent = mapf(voltage, 76.32, 79.92, 30, 40);
+  } else if (voltage > 67.44) {
+    battPercent = mapf(voltage, 67.44, 76.32, 20, 30);
+  } else if (voltage > 63.6) {
+    battPercent = mapf(voltage, 63.6, 67.44, 10, 20);
+  } else if (voltage > 60) {
+    battPercent = mapf(voltage, 60, 63.6, 0, 10);
+  }
+  return constrain(battPercent, 0, 100);
+}
+
+
+// inspired by https://github.com/rlogiacco/BatterySense/
+// https://www.desmos.com/calculator/7m9lu26vpy
+uint8_t battery_sigmoidal(float voltage, uint16_t minVoltage, uint16_t maxVoltage) {
+  uint8_t result = 105 - (105 / (1 + pow(1.724 * (voltage - minVoltage)/(maxVoltage - minVoltage), 5.5)));
+  return result >= 100 ? 100 : result;
+}

--- a/power.ino
+++ b/power.ino
@@ -4,26 +4,25 @@
 // simple set of data points from load testing
 float getBatteryPercent(float voltage) {
   float battPercent = 0;
-  if (voltage > 92.4) {
-    battPercent = mapf(voltage, 92.4, 100.8, 90, 100);
-  } else if (voltage > 90.48) {
-    battPercent = mapf(voltage, 90.48, 92.4, 80, 90);
-  } else if (voltage > 87.84) {
-    battPercent = mapf(voltage, 87.84, 90.48, 70, 80);
+  
+  if (voltage > 92.88) {
+    battPercent = mapf(voltage, 92.88, 94.8, 80, 90);
+  } else if (voltage > 90.24) {
+    battPercent = mapf(voltage, 90.24, 92.88, 70, 80);
   } else if (voltage > 85.44) {
-    battPercent = mapf(voltage, 85.44, 87.84, 60, 70);
+    battPercent = mapf(voltage, 85.44, 90.24, 60, 70);
+  } else if (voltage > 84.72) {
+    battPercent = mapf(voltage, 84.72, 85.44, 50, 60);
   } else if (voltage > 82.32) {
-    battPercent = mapf(voltage, 82.32, 85.44, 50, 60);
-  } else if (voltage > 79.92) {
-    battPercent = mapf(voltage, 79.92, 82.32, 40, 50);
-  } else if (voltage > 76.32) {
-    battPercent = mapf(voltage, 76.32, 79.92, 30, 40);
-  } else if (voltage > 67.44) {
-    battPercent = mapf(voltage, 67.44, 76.32, 20, 30);
-  } else if (voltage > 63.6) {
-    battPercent = mapf(voltage, 63.6, 67.44, 10, 20);
+    battPercent = mapf(voltage, 82.32, 84.72, 40, 50);
+  } else if (voltage > 78.72) {
+    battPercent = mapf(voltage, 78.72, 82.32, 30, 40);
+  } else if (voltage > 69.84) {
+    battPercent = mapf(voltage, 69.84, 78.72, 20, 30);
+  } else if (voltage > 68.4) {
+    battPercent = mapf(voltage, 68.4, 69.84, 10, 20);
   } else if (voltage > 60) {
-    battPercent = mapf(voltage, 60, 63.6, 0, 10);
+    battPercent = mapf(voltage, 60, 68.4, 0, 10);
   }
   return constrain(battPercent, 0, 100);
 }

--- a/sp140.ino
+++ b/sp140.ino
@@ -1,11 +1,13 @@
 // Copyright 2020 <Zach Whitehead>
 
+// track flight timer
 void handleFlightTime() {
   if (!armed) {
     throttledFlag = true;
     throttled = false;
   }
   if (armed) {
+    // start the timer when armed and throttle is above the threshold
     if (throttlePercent > 30 && throttledFlag) {
       throttledAtMillis = millis();
       throttledFlag = false;
@@ -103,8 +105,9 @@ void dispValue(float value, float &prevVal, int maxDigits, int precision, int x,
   prevVal = value;
 }
 
+// Start the bmp388 sensor
 void initBmp() {
-  bmp.begin();
+  bmp.begin_I2C();
   bmp.setOutputDataRate(BMP3_ODR_25_HZ);
   bmp.setTemperatureOversampling(BMP3_OVERSAMPLING_2X);
   bmp.setPressureOversampling(BMP3_OVERSAMPLING_8X);
@@ -142,6 +145,7 @@ void handleTelemetry() {
   // printRawSentence();
 }
 
+// run checksum and return true if valid
 bool enforceFletcher16() {
   // Check checksum, revert to previous data if bad:
   word checksum = (unsigned short)(word(escData[19], escData[18]));
@@ -176,7 +180,7 @@ bool enforceFletcher16() {
 
 // Not used
 void enforceChecksum() {
-  //Check checksum, revert to previous data if bad:
+  // Check checksum, revert to previous data if bad:
   word checksum = word(escData[19], escData[18]);
   int sum = 0;
   for (int i=0; i<ESC_DATA_SIZE-2; i++) {
@@ -202,7 +206,7 @@ void enforceChecksum() {
   }
 }
 
-
+// for debugging
 void printRawSentence() {
   Serial.print(F("DATA: "));
   for (int i = 0; i < ESC_DATA_SIZE; i++) {
@@ -284,14 +288,6 @@ void parseData() {
   // Serial.println(checksum);
 }
 
-void vibrateAlert() {
-  if (!ENABLE_VIB) { return; }
-  int effect = 15;  // 1 through 117 (see example sketch)
-  vibe.setWaveform(0, effect);
-  vibe.setWaveform(1, 0);
-  vibe.go();
-}
-
 void vibrateNotify() {
   if (!ENABLE_VIB) { return; }
 
@@ -300,7 +296,7 @@ void vibrateNotify() {
   vibe.go();
 }
 
-
+// throttle easing function based on performance mode
 int limitedThrottle(int current, int last, int threshold) {
   prevPotLvl = current;
 
@@ -317,6 +313,7 @@ int limitedThrottle(int current, int last, int threshold) {
   }
 }
 
+// ring buffer for voltage readings
 float getBatteryVoltSmoothed() {
   float avg = 0.0;
 

--- a/sp140.ino
+++ b/sp140.ino
@@ -327,26 +327,3 @@ float getBatteryVoltSmoothed() {
   }
   return avg;
 }
-
-float getBatteryPercent(float voltage) {
-  //Serial.print("percent v ");
-  //Serial.println(voltage);
-
-  int battPercent = 0;
-  if (voltage < BATT_MIN_V) { return battPercent; }  // just stop here if low
-
-  if (telemetryData.volts >= BATT_MID_V) {
-    battPercent = mapf(voltage, BATT_MID_V, BATT_MAX_V, 50.0, 100.0);
-  } else {
-    battPercent = mapf(voltage, BATT_MIN_V, BATT_MID_V, 0.0, 50.0);
-  }
-  // batteryPercent = battery_sigmoidal(voltage, 58.0, BATT_MAX_V);
-  return constrain(battPercent, 0, 100);
-}
-
-// inspired by https://github.com/rlogiacco/BatterySense/
-// https://www.desmos.com/calculator/7m9lu26vpy
-uint8_t battery_sigmoidal(float voltage, uint16_t minVoltage, uint16_t maxVoltage) {
-  uint8_t result = 105 - (105 / (1 + pow(1.724 * (voltage - minVoltage)/(maxVoltage - minVoltage), 5.5)));
-  return result >= 100 ? 100 : result;
-}

--- a/sp140.ino
+++ b/sp140.ino
@@ -105,8 +105,9 @@ void dispValue(float value, float &prevVal, int maxDigits, int precision, int x,
 
 void initBmp() {
   bmp.begin();
-  bmp.setTemperatureOversampling(BMP3_OVERSAMPLING_8X);
-  bmp.setPressureOversampling(BMP3_OVERSAMPLING_4X);
+  bmp.setOutputDataRate(BMP3_ODR_25_HZ);
+  bmp.setTemperatureOversampling(BMP3_OVERSAMPLING_2X);
+  bmp.setPressureOversampling(BMP3_OVERSAMPLING_8X);
   bmp.setIIRFilterCoeff(BMP3_IIR_FILTER_COEFF_3);
 }
 


### PR DESCRIPTION
Due to the display update thread taking ~95ms each loop it sometimes caused the amp hour counter to miss which results in a slightly low kWh display. 
This PR 
- updates the screen less often 10/fps -> 5/fps
- updates trackPower function to be flexible enough to be called as little or often while still counting watt hours
- calls trackPower() twice as often to get more accurate average power consumption 
- new battery curve with 10 data points
- library and platform (v1.7.5) updates