### PR TITLE
Tweak BMP sensitivity

### DIFF
--- a/src/sp140/sp140-helpers.ino
+++ b/src/sp140/sp140-helpers.ino
@@ -111,7 +111,7 @@ void initBmp() {
   bmp.setOutputDataRate(BMP3_ODR_25_HZ);
   bmp.setTemperatureOversampling(BMP3_OVERSAMPLING_2X);
   bmp.setPressureOversampling(BMP3_OVERSAMPLING_4X);
-  bmp.setIIRFilterCoeff(BMP3_IIR_FILTER_COEFF_63);
+  bmp.setIIRFilterCoeff(BMP3_IIR_FILTER_COEFF_31);
 }
 
 void buzzInit(bool enableBuz) {
@@ -129,7 +129,7 @@ void buzzInit(bool enableBuz) {
   }
 }
 
-void prepareSerialRead() {
+void prepareSerialRead() {  // TODO needed?
   while (Serial5.available() > 0) {
     byte t = Serial5.read();
   }

--- a/src/sp140/sp140-helpers.ino
+++ b/src/sp140/sp140-helpers.ino
@@ -229,7 +229,9 @@ void parseData() {
     telemetryData.volts += 1.5;  // calibration
   }
 
-  voltageBuffer.push(telemetryData.volts);
+  if (telemetryData.volts > 1) {  // ignore empty data
+    voltageBuffer.push(telemetryData.volts);
+  }
 
   // Serial.print(F("Volts: "));
   // Serial.println(telemetryData.volts);

--- a/src/sp140/sp140-helpers.ino
+++ b/src/sp140/sp140-helpers.ino
@@ -110,8 +110,8 @@ void initBmp() {
   bmp.begin_I2C();
   bmp.setOutputDataRate(BMP3_ODR_25_HZ);
   bmp.setTemperatureOversampling(BMP3_OVERSAMPLING_2X);
-  bmp.setPressureOversampling(BMP3_OVERSAMPLING_8X);
-  bmp.setIIRFilterCoeff(BMP3_IIR_FILTER_COEFF_3);
+  bmp.setPressureOversampling(BMP3_OVERSAMPLING_4X);
+  bmp.setIIRFilterCoeff(BMP3_IIR_FILTER_COEFF_63);
 }
 
 void buzzInit(bool enableBuz) {

--- a/src/sp140/sp140-helpers.ino
+++ b/src/sp140/sp140-helpers.ino
@@ -111,7 +111,7 @@ void initBmp() {
   bmp.setOutputDataRate(BMP3_ODR_25_HZ);
   bmp.setTemperatureOversampling(BMP3_OVERSAMPLING_2X);
   bmp.setPressureOversampling(BMP3_OVERSAMPLING_4X);
-  bmp.setIIRFilterCoeff(BMP3_IIR_FILTER_COEFF_31);
+  bmp.setIIRFilterCoeff(BMP3_IIR_FILTER_COEFF_15);
 }
 
 void buzzInit(bool enableBuz) {

--- a/src/sp140/sp140.ino
+++ b/src/sp140/sp140.ino
@@ -505,6 +505,7 @@ void displayMessage(char *message) {
 
 void setCruise() {
   // IDEA: fill a "cruise indicator" as long press activate happens
+  // or gradually change color from blue to yellow with time
   if (!throttleSafe()) {  // using pot/throttle
     cruiseLvl = pot.getValue();  // save current throttle val
     cruising = true;


### PR DESCRIPTION
Use less oversampling and more smoothing on bmp388 baro.
This should lead to faster reads. Accuracy is limited by physical case design anyways. 