### PR TITLE
Remove platform_packages

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -78,15 +78,6 @@ framework = arduino
 ; Out of 16Mbyte available
 board_build.filesystem_size = 14M ; 14 Mbyte for filesystem and 2 Mbyte for program
 
-; inject core package.. not yet registered with PlatformIO
-; registry, so pull working version directly from git / download page.
-; note that download link for toolchain is specific for OS. see https://github.com/earlephilhower/pico-quick-toolchain/releases.
-platform_packages =
-    framework-arduinopico@https://github.com/earlephilhower/arduino-pico.git
-    ;maxgerhardt/toolchain-pico@https://github.com/earlephilhower/pico-quick-toolchain/releases/download/1.3.4-d/x86_64-w64-mingw32.elf2uf2-2062372.220608.zip
-    ;maxgerhardt/toolchain-pico@https://github.com/earlephilhower/pico-quick-toolchain/releases/download/1.3.4-d/x86_64-apple-darwin14.elf2uf2-2062372.220608.tar.gz
-    maxgerhardt/toolchain-pico@https://github.com/earlephilhower/pico-quick-toolchain/releases/download/1.3.4-d/x86_64-linux-gnu.arm-none-eabi-46ea946.220608.tar.gz
-
 build_flags = -DRP_PIO
 src_folder = sp140
 extra_scripts = pre:extra_script.py


### PR DESCRIPTION
1. toolchain-pico was renamed to `toolchain-rp2040-earlephilhower` and is uploaded in the registry, the new platform version automatically uses this, so no more need to source it from a download link
2. `framework-arduinopico` is automatically sourced from `https://github.com/earlephilhower/arduino-pico.git` (latest bleeding edge version) by the platform, no need to specify that

Also would enable CI to run on all operatings systems instead of just Linux.

Note that for stability of compilation, you might actually want to postfix the `platform` value and framework-arduinopico value  (for which you would need `platform_packages` again) with their git commit hash (e.g., `#1b8624b35a74978dad63624f0ef063ef89ecdf53` and `#fdf30febea7989ab8c5e451d3a1c22c15113d500`), so that successfull compilation + workings can be verified with one core and platform version. But this PR keeps compatibility with the current behavior.