### PR TITLE
Coulomb counting for SOC estimation

### DIFF
--- a/inc/sp140/globals.h
+++ b/inc/sp140/globals.h
@@ -32,6 +32,11 @@ uint32_t _eRPM = 0;
 uint16_t _inPWM = 0;
 uint16_t _outPWM = 0;
 
+// Battery information
+unsigned int cellsInSeries = 0;
+unsigned int cellsInParallel = 0;
+unsigned int exactCapacityWh = 0;
+
 // ESC Telemetry
 float prevVolts = 0;
 float prevAmps = 0;

--- a/inc/sp140/globals.h
+++ b/inc/sp140/globals.h
@@ -24,6 +24,8 @@ float seconds = 0;
 float prevSeconds = 0;
 float hours = 0;  // logged flight hours
 float wattsHoursUsed = 0;
+float initialBatteryEnergy = 0;
+bool analysisFlag = true;
 
 uint16_t _volts = 0;
 uint16_t _temperatureC = 0;

--- a/inc/sp140/shared-config.h
+++ b/inc/sp140/shared-config.h
@@ -4,6 +4,7 @@
 
 // Batt setting now configurable by user. Read from device data
 #define BATT_MIN_V 60.0  // 24 * 2.5V per cell
+#define CELL_CAPACITY_WH 15.5
 
 // Calibration
 #define MAMP_OFFSET 200
@@ -16,6 +17,10 @@
 #define POT_SAFE_LEVEL 0.05 * 4096  // 5% or less
 
 #define DEFAULT_SEA_PRESSURE 1013.25
+
+// Initial SOC estimation analysis period
+#define BATTERY_ANALYSIS_START 1000
+#define BATTERY_ANALYSIS_END 30000
 
 // Library config
 #define NO_ADAFRUIT_SSD1306_COLOR_COMPATIBILITY

--- a/src/sp140/power.ino
+++ b/src/sp140/power.ino
@@ -4,9 +4,14 @@
 void updateBatteryPercent() {
   if (millis() < BATTERY_ANALYSIS_END) {
     batteryPercent = analyzeInitialBatteryPercent();
-  } else {
-    float currentEnergy = batteryPercent / 100 * exactCapacityWh;
-    float newEnergy = currentEnergy - wattsHoursUsed;
+  }
+  else {
+    // set initial battery energy only once
+    if (analysisFlag) {
+      initialBatteryEnergy = batteryPercent / 100 * exactCapacityWh;
+      analysisFlag = false;
+    }
+    float newEnergy = initialBatteryEnergy - wattsHoursUsed;
     batteryPercent = newEnergy / exactCapacityWh * 100;
   }
   batteryPercent = constrain(batteryPercent, 0, 100);
@@ -18,6 +23,7 @@ float analyzeInitialBatteryPercent() {
   float avgVoltage = getBatteryVoltSmoothed();
   float batteryPercent = getBatteryPercent(avgVoltage);
 
+  // wait a little before calculating moving average (due to potential voltage drop from starting the motor)
   if (millis() > BATTERY_ANALYSIS_START) {
     initialSOCMovingAvg = (initialSOCMovingAvg * numInitialSOCReadings + batteryPercent) / (numInitialSOCReadings + 1);
     numInitialSOCReadings++;

--- a/src/sp140/power.ino
+++ b/src/sp140/power.ino
@@ -60,7 +60,3 @@ uint8_t battery_sigmoidal(float voltage, uint16_t minVoltage, uint16_t maxVoltag
   uint8_t result = 105 - (105 / (1 + pow(1.724 * (voltage - minVoltage)/(maxVoltage - minVoltage), 5.5)));
   return result >= 100 ? 100 : result;
 }
-
-void estimate_initial_soc() {
-  // measured voltage, divide by number of cells in series
-}

--- a/src/sp140/power.ino
+++ b/src/sp140/power.ino
@@ -9,6 +9,7 @@ void updateBatteryPercent() {
     float newEnergy = currentEnergy - wattsHoursUsed;
     batteryPercent = newEnergy / exactCapacityWh * 100;
   }
+  batteryPercent = constrain(batteryPercent, 0, 100);
 }
 
 // get initial battery percent and update moving average
@@ -19,6 +20,7 @@ float analyzeInitialBatteryPercent() {
 
   if (millis() > BATTERY_ANALYSIS_START) {
     initialSOCMovingAvg = (initialSOCMovingAvg * numInitialSOCReadings + batteryPercent) / (numInitialSOCReadings + 1);
+    numInitialSOCReadings++;
     return initialSOCMovingAvg;
   }
   return batteryPercent;

--- a/src/sp140/sp140-helpers.ino
+++ b/src/sp140/sp140-helpers.ino
@@ -449,3 +449,16 @@ float getBatteryVoltSmoothed() {
   }
   return avg;
 }
+
+// Update battery information
+void updateBatteryInfo() {
+  cellsInSeries = 24;
+  if (deviceData.batt_size == 2000) {
+    cellsInParallel = 6;
+  }
+  // default to battery size of 4000Wh
+  else {
+    cellsInParallel = 10;
+  }
+  exactCapacityWh = cellsInSeries * cellsInParallel * CELL_CAPACITY_WH;
+}

--- a/src/sp140/sp140.ino
+++ b/src/sp140/sp140.ino
@@ -394,12 +394,14 @@ void updateDisplay() {
   //display.print("kW");
 
   display.setTextColor(BLACK);
-  float avgVoltage = getBatteryVoltSmoothed();
-  batteryPercent = getBatteryPercent(avgVoltage);  // multi-point line
+  updateBatteryPercent();
+
   // change battery color based on charge
   int batt_width = map((int)batteryPercent, 0, 100, 0, 108);
   display.fillRect(0, 0, batt_width, 36, batt2color(batteryPercent));
 
+  // check voltage to see if battery is dead (more reliable than percent)
+  float avgVoltage = getBatteryVoltSmoothed();
   if (avgVoltage < BATT_MIN_V) {
     if (batteryFlag) {
       batteryFlag = false;

--- a/src/sp140/sp140.ino
+++ b/src/sp140/sp140.ino
@@ -79,6 +79,9 @@ uint32_t cruisedAtMilisMilis = 0;
 unsigned int armedSecs = 0;
 unsigned int last_throttle = 0;
 
+float initialSOCMovingAvg = 0;
+unsigned int numInitialSOCReadings = 0;
+
 #pragma message "Warning: OpenPPG software is in beta"
 
 // the setup function runs once when you press reset or power the board
@@ -601,6 +604,6 @@ void trackPower() {
   prevPwrMillis = currentPwrMillis;
 
   if (armed) {
-    wattsHoursUsed += round(watts/60/60*msec_diff)/1000.0;
+    wattsHoursUsed += (watts/60/60*msec_diff)/1000.0;
   }
 }


### PR DESCRIPTION
Uses the existing wattHoursUsed variable to continually update the estimate of SOC.
At startup, analyze the initial SOC using the getBatteryPercent function. Once this period ends, it uses the initial SOC estimation and subtracts the wattHoursUsed to determine the new SOC. Will likely overestimate the battery percent since the actual battery capacity will probably be lower than the nominal capacity due to heat loss, but doesn't rely as much on voltage (which may be inaccurate due to the flat curve of Li-on batteries)