### PR TITLE
Webusb sync command

### DIFF
--- a/src/sp140/altimeter.cpp
+++ b/src/sp140/altimeter.cpp
@@ -26,9 +26,13 @@ void setGroundAltitude(const STR_DEVICE_DATA_140_V1& deviceData) {
 bool setupAltimeter(bool altWire) {
   TwoWire* wire = &Wire;
 
-  if (altWire) {wire = &Wire1; }
+  if (altWire) {
+    wire = &Wire1;
+  }
 
-  if (!bmp.begin_I2C(BMP3XX_DEFAULT_ADDRESS, wire)) return false;
+  if (!bmp.begin_I2C(BMP3XX_DEFAULT_ADDRESS, wire)) {
+    return false;
+  }
   bmp.setOutputDataRate(BMP3_ODR_25_HZ);
   bmp.setTemperatureOversampling(BMP3_OVERSAMPLING_2X);
   bmp.setPressureOversampling(BMP3_OVERSAMPLING_4X);

--- a/src/sp140/display.cpp
+++ b/src/sp140/display.cpp
@@ -283,7 +283,9 @@ void updateDisplay(
   float escTemp;
   escTemp = escTelemetry.temperatureC;
 
-  if (escTemp >= 100) { canvas.setTextColor(currentTheme->error_text); }  // If temperature is 100C+, display in red.
+  if (escTemp >= 100) {
+    canvas.setTextColor(currentTheme->error_text);  // If temperature is 100C+, display in red.
+  }
   if (escTemp == __FLT_MIN__ || escTemp == 0.0) {  // If temperature is not available, display a question mark.
     canvas.printf("?%c", 247);
   } else {  // Otherwise, display the temperature. (in degrees C)

--- a/src/sp140/extra-data.ino
+++ b/src/sp140/extra-data.ino
@@ -1,6 +1,28 @@
 // Copyright 2020 <Zach Whitehead>
 // OpenPPG
 
+/**
+ * WebUSB Protocol Documentation
+ *
+ * Available Commands:
+ * - "rbl": Reboot to bootloader for firmware updates
+ * - "sync": Request current device settings and state
+ *
+ * Response Format:
+ * {
+ *   "mj_v": number,        // Major version
+ *   "mi_v": number,        // Minor version
+ *   "arch": string,        // Architecture ("SAMD21" or "RP2040")
+ *   "scr_rt": number,      // Screen rotation
+ *   "ar_tme": number,      // Armed time in minutes
+ *   "m_tmp": bool,         // Metric temperature
+ *   "m_alt": bool,         // Metric altitude
+ *   "prf": number,         // Performance mode
+ *   "sea_p": float,        // Sea pressure
+ *   "thm": number          // Theme
+ * }
+ */
+
 // ** Logic for EEPROM **
 # define EEPROM_OFFSET 0  // Address of first byte of EEPROM
 
@@ -80,17 +102,35 @@ void resetDeviceData() {
   writeDeviceData();
 }
 
-// ** Logic for WebUSB **
-// Callback for when the USB connection state changes
+/**
+ * WebUSB connection state change callback.
+ * Updates LED indicators to show connection status.
+ *
+ * @param connected True if WebUSB connection established, false if disconnected
+ */
 void line_state_callback(bool connected) {
   setLEDColor(connected ? LED_BLUE : LED_GREEN);
   setLEDs(connected);
 }
 
-// customized for sp140
+/**
+ * Parses and handles incoming WebUSB JSON messages.
+ * Messages can either be commands or settings updates.
+ *
+ * Command messages are processed immediately and return.
+ * Settings messages must have major_v >= 5 and contain valid settings values.
+ *
+ * All settings changes are validated, sanitized, and saved to EEPROM.
+ * Current device state is sent back after successful settings changes.
+ *
+ * Error Handling:
+ * - Invalid JSON: Silently ignored
+ * - Invalid version: Silently ignored
+ * - Invalid settings: Sanitized to default values
+ */
 void parse_usb_serial() {
 #ifdef USE_TINYUSB
-  const size_t capacity = JSON_OBJECT_SIZE(13) + 90;
+  const size_t capacity = JSON_OBJECT_SIZE(13) + 90;  // Size for max message
   DynamicJsonDocument doc(capacity);
   deserializeJson(doc, usb_web);
 
@@ -128,6 +168,12 @@ void parse_usb_serial() {
 #endif
 }
 
+/**
+ * Validates and sanitizes device settings to ensure they are within acceptable ranges.
+ * Each setting is checked against its valid range and set to a default if invalid.
+ *
+ * @return true if any values were changed during sanitization, false if all valid
+ */
 bool sanitizeDeviceData() {
   bool changed = false;
   // Ensure screen rotation is either 1 or 3, default to 3

--- a/src/sp140/extra-data.ino
+++ b/src/sp140/extra-data.ino
@@ -85,8 +85,6 @@ void resetDeviceData() {
 void line_state_callback(bool connected) {
   setLEDColor(connected ? LED_BLUE : LED_GREEN);
   setLEDs(connected);
-
-  if ( connected ) send_usb_serial();
 }
 
 // customized for sp140
@@ -96,11 +94,16 @@ void parse_usb_serial() {
   DynamicJsonDocument doc(capacity);
   deserializeJson(doc, usb_web);
 
-  if (doc["command"] && doc["command"] == "rbl") {
-    // display.fillScreen(DEFAULT_BG_COLOR);
-    //TODO display ("BL - UF2");
-    rebootBootloader();
-    return;  // run only the command
+  if (doc["command"]) {
+    if (doc["command"] == "rbl") {
+      // display.fillScreen(DEFAULT_BG_COLOR);
+      //TODO display ("BL - UF2");
+      rebootBootloader();
+      return;  // run only the command
+    } else if (doc["command"] == "sync") {
+      send_usb_serial();
+      return;  // run only the command
+    }
   }
 
   if (doc["major_v"] < 5) return; // ignore old versions
@@ -121,7 +124,7 @@ void parse_usb_serial() {
 
   vTaskResume(updateDisplayTaskHandle);
 
-  send_usb_serial();
+  send_usb_serial(); // Send back updated data after settings change
 #endif
 }
 

--- a/src/sp140/vibration.cpp
+++ b/src/sp140/vibration.cpp
@@ -7,7 +7,9 @@ Adafruit_DRV2605 vibeMotor;
 bool vibeMotorInitialized = false;
 
 bool initVibeMotor() {
-  if (!vibeMotor.begin(&Wire1)) { return false; }
+  if (!vibeMotor.begin(&Wire1)) {
+    return false;
+  }
   vibeMotor.selectLibrary(3);
   vibeMotor.setMode(DRV2605_MODE_INTTRIG);
   vibeMotorInitialized = true;
@@ -22,7 +24,9 @@ void pulseVibeMotor() {
 }
 
 bool runVibePattern(const unsigned int pattern[], int patternSize) {
-  if (!vibeMotorInitialized) { return false; }
+  if (!vibeMotorInitialized) {
+    return false;
+  }
 
   for (int i = 0; i < patternSize; i++) {
     vibeMotor.setWaveform(i, pattern[i]);


### PR DESCRIPTION
This update modifies the behavior of the OpenPPG controller to improve reliability. Now, the config client must actively request controller information instead of the controller automatically sending it upon connection.

*Why this change?*
If the controller encounters an error while sending information automatically, it could freeze or reboot. This would prevent other critical commands, such as rebooting into the bootloader, from being sent. By requiring a request, the system ensures greater stability and allows for recovery actions if needed.