### PR TITLE
Fix reboot on arm while BLE-connected (State Update task stack overflow)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,41 @@
+# Release Notes
+
+## v8.0 — build 1190 (2026-06-05)
+
+### Fixed
+
+- **Controller reboots when arming with a phone connected over Bluetooth.**
+  Completing the arm sequence while a BLE central (the companion app) was
+  paired and connected caused the controller to panic and reboot instead of
+  arming. Disconnected/unpaired, arming worked normally.
+
+  **Root cause:** on every arm/disarm, `deviceStateUpdateTask` pushes the new
+  device state to the app through a BLE characteristic notification. That task
+  was created with only a **2 KB stack**, but NimBLE's `notify()` descends
+  through the full BLE host stack (GATT → ATT → L2CAP → HCI), which needs more
+  than 2 KB. The result was a FreeRTOS stack-overflow trap
+  (`vApplicationStackOverflowHook`) → reboot. The notify only runs while a
+  central is connected, which is why the crash appeared only after pairing.
+
+  **Fix:** raised the `deviceStateUpdateTask` stack from 2048 to **8192 bytes**,
+  matching the sibling `bleStateUpdateTask` that performs the same kind of
+  notification. Added comments at both the stack allocation and the `notify()`
+  call so the requirement isn't lost. (`src/sp140/main.cpp`)
+
+  **Why it surfaced now:** the undersized stack had been latent since late
+  January, but only became reachable after device-state notifications were
+  re-enabled (2026-05-06) and the BLE pairing feature merged (PR #110), which
+  together made a connected central — and therefore the notify path — the normal
+  case during arming. The earlier NimBLE migration (replacing ESP32 BLE) is what
+  made a 2 KB stack insufficient in the first place; the same class of overflow
+  was already fixed for another task in `BLE: fix Tmr Svc stack overflow`.
+
+### Known issues
+
+- **Spurious "arm sequence started" logged right after arming.** Because the arm
+  hold completes while the button is still pressed and the press timer is reset
+  at completion, the subsequent button *release* is mis-read as a fresh
+  quick-click and starts a new arm sequence. It self-cancels after the 1.5 s
+  sequence timeout, so it's harmless log-noise in normal use, but the
+  button-handling logic in `buttonHandlerTask` should be tightened so the
+  post-arm release can't open a new sequence. Tracked as a separate fix.

--- a/src/sp140/main.cpp
+++ b/src/sp140/main.cpp
@@ -201,6 +201,12 @@ void deviceStateUpdateTask(void *parameter) {
         vTaskDelay(pdMS_TO_TICKS(20));  // Give BLE stack breathing room
         pDeviceStateCharacteristic->setValue(&state, sizeof(state));
         if (!isOtaInProgress()) {
+          // notify() descends through the full NimBLE host stack
+          // (GATT/ATT/L2CAP/HCI) — it is the deepest call this task makes.
+          // This task's stack MUST stay large (>= 8192; see the xTaskCreate for
+          // "State Update Task"). A 2 KB stack here overflowed and rebooted the
+          // controller on arm whenever a BLE central was connected. Do not
+          // shrink the stack or move this notify() onto a smaller-stack task.
           pDeviceStateCharacteristic->notify();
         }
       }
@@ -686,7 +692,11 @@ void setupTasks() {
               &ctrlSensorTaskHandle);
   xTaskCreatePinnedToCore(bleNotifyTask, "BLENotify", 8192, NULL, 1,
                           &bleNotifyTaskHandle, 1);
-  xTaskCreate(deviceStateUpdateTask, "State Update Task", 2048, NULL, 1,
+  // 8192 (not 2048): this task calls pDeviceStateCharacteristic->notify() on
+  // arm. NimBLE's notify path (GATT/ATT/L2CAP/HCI) is deep enough to overflow a
+  // 2KB stack once a central is connected, causing a reboot-on-arm-while-paired.
+  // Matches the proven-safe stack of bleStateUpdateTask, which notifies the same way.
+  xTaskCreate(deviceStateUpdateTask, "State Update Task", 8192, NULL, 1,
               &deviceStateUpdateTaskHandle);
   xTaskCreatePinnedToCore(bleStateUpdateTask, "BLEStateUpdate", 8192, NULL, 1,
                           &bleStateUpdateTaskHandle, 1);


### PR DESCRIPTION
## Summary

Completing the arm sequence while a phone is paired/connected over BLE caused the controller to panic and **reboot instead of arming**. Disconnected/unpaired, arming worked normally. This fixes that crash.

## Root cause

On every arm/disarm, `deviceStateUpdateTask` notifies the BLE device-state characteristic. That task was created with only a **2 KB stack**, but NimBLE's `notify()` descends through the full BLE host stack (GATT → ATT → L2CAP → HCI), which needs more than 2 KB. The overflow tripped the FreeRTOS stack-overflow hook (`vApplicationStackOverflowHook`) → reboot. The notify only runs while a central is connected, which is why the crash only appeared after pairing.

Captured backtrace (serial, exception decoder):

```
Device State Changed to: ARMED          <- immediately before the panic
***ERROR*** A stack overflow in task State Update Ta has been detected.
  #2  vApplicationStackOverflowHook
  #3  vTaskSwitchContext
Rebooting...
[DIAG] ... rst=PANIC ... prev=DISARMED
```

## Fix

Raise `deviceStateUpdateTask`'s stack from `2048` → **`8192`**, matching the sibling `bleStateUpdateTask` that performs the same kind of notification. Added comments at both the stack allocation and the `notify()` call so the requirement isn't silently reduced again.

## Why it surfaced now

The undersized stack has been latent since late January, but only became reachable after device-state notifications were re-enabled (`5dbf2c9`, 2026-05-06) and BLE pairing shipped (#110) — together those made a connected central, and therefore the notify path, the normal case during arming. The earlier NimBLE migration is what made a 2 KB stack insufficient in the first place; the same class of overflow was already patched for another task in *"BLE: fix Tmr Svc stack overflow"*.

## Testing

- Built for `OpenPPG-CESP32S3-CAN-SP140` and flashed to hardware.
- **Reproduced** on the pre-fix build: armed while paired → instant reboot (twice), with the backtrace above.
- **Fixed build**: armed/disarmed repeatedly with a phone connected (`connected=1`) — no reboot, uptime continuous across multiple cycles. ✅

## Known follow-up (not in this PR)

Releasing the button at the end of the arm hold is mis-read as a new quick-click and starts a spurious arm sequence that self-cancels after the 1.5 s timeout. Harmless log-noise today, but `buttonHandlerTask` should be tightened separately so the post-arm release can't open a new sequence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
